### PR TITLE
Removed low frequency operation

### DIFF
--- a/Arduino/SensebenderMicro/SensebenderMicro.ino
+++ b/Arduino/SensebenderMicro/SensebenderMicro.ino
@@ -200,13 +200,6 @@ void loop() {
   sendBattery ++;
   bool forceTransmit = false;
   transmission_occured = false;
-#ifndef MY_OTA_FIRMWARE_FEATURE
-  if ((measureCount == 5) && highfreq) 
-  {
-    clock_prescale_set(clock_div_8); // Switch to 1Mhz for the reminder of the sketch, save power.
-    highfreq = false;
-  } 
-#endif
   
   if (measureCount > FORCE_TRANSMIT_INTERVAL) { // force a transmission
     forceTransmit = true; 


### PR DESCRIPTION
the switch to lower frequency operation is not needed, as the battery life is not reduced dramatically, and it confuses users more than necessary, when communication is borked after aprox. 5 minutes due to changes to the oscillator frequency.