### PR TITLE
Present BATT_SENSOR as sensorType S_MULTIMETER

### DIFF
--- a/Arduino/SensebenderMicro/SensebenderMicro.ino
+++ b/Arduino/SensebenderMicro/SensebenderMicro.ino
@@ -184,7 +184,7 @@ void presentation()  {
   present(CHILD_ID_HUM,S_HUM);
     
 #ifdef BATT_SENSOR
-  present(BATT_SENSOR, S_POWER);
+  present(BATT_SENSOR, S_MULTIMETER);
 #endif
 }
 


### PR DESCRIPTION
As msgBatt has variable-type 'V_VOLTAGE' it needs type 'S_MULTIMETER'.
Without this the entity is not being displayed in Home Assistant.